### PR TITLE
Downgrade tmdblib

### DIFF
--- a/Jellyfin.Plugin.Tmdb.Trailers/Jellyfin.Plugin.Tmdb.Trailers.csproj
+++ b/Jellyfin.Plugin.Tmdb.Trailers/Jellyfin.Plugin.Tmdb.Trailers.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-        <PackageReference Include="TMDbLib" Version="2.0.0" />
+        <PackageReference Include="TMDbLib" Version="1.9.2" />
         <PackageReference Include="YoutubeExplode" Version="6.2.14" />
         <PackageReference Include="YoutubeExplode.Converter" Version="6.2.14" />
     </ItemGroup>


### PR DESCRIPTION
Jellyfin core provides v1.9.2

In Jellyfin 10.9 plugins will be able to supply duplicate dlls